### PR TITLE
Updating to Gradle 4 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ android:
     - tools
 
     # The BuildTools version used by the project
-    - build-tools-28.0.3
+    - build-tools-29.0.3
 
     # The SDK version used to compile the project
-    - android-28
+    - android-29
 
     # Additional components
     - extra-google-google_play_services

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: android
-
 jdk: oraclejdk8
 
 before_cache:
@@ -16,7 +15,6 @@ cache:
 
 before_install:
   - chmod +x gradlew
-  # - android list target
 
 android:
   components:
@@ -40,12 +38,19 @@ android:
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
-    # - sys-img-armeabi-v7a-android-23
-    # - sys-img-x86-android-17
+    - android-23
+    - sys-img-armeabi-v7a-android-23
+    #- sys-img-x86-android-28
 
 script:
   - ./gradlew clean
-  - ./gradlew build jacocoTestReport assembleAndroidTest test
+  - ./gradlew assembleDebug
+  - echo no | android create avd --force -n test -t android-23 --abi armeabi-v7a
+  - emulator -avd test -no-skin -no-window &
+  - android-wait-for-emulator
+  - while [ "`adb shell getprop sys.boot_completed | tr -d '\r' `" != "1" ] ; do sleep 1; done
+  - adb shell input keyevent 82 &
+  - ./gradlew jacocoTestReportDebug
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.5.1'
+    classpath 'com.android.tools.build:gradle:4.0.0'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.3.50'
+  ext.versions = [
+      kotlin: '1.3.50',
+      jacoco: '0.8.4',
+  ]
   repositories {
     google()
     jcenter()
@@ -12,10 +15,10 @@ buildscript {
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
-    classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+    classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0"
 
     classpath 'com.google.gms:google-services:4.3.2'
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 18 08:32:14 MST 2019
+#Fri Jul 03 19:20:15 MST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/weather-app/build.gradle
+++ b/weather-app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'jacoco-android'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 android {
   compileSdkVersion 28
@@ -38,18 +38,13 @@ android {
   testOptions {
     unitTests.returnDefaultValues = true
     unitTests.includeAndroidResources = true
-    unitTests.all {
-      jacoco {
-        includeNoLocationClasses = true
-      }
-    }
   }
 }
 
 dependencies {
   implementation project(':weather-library')
   implementation fileTree(dir: 'libs', include: ['*.jar'])
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
 
   implementation 'androidx.appcompat:appcompat:1.0.0'
   implementation 'androidx.legacy:legacy-support-v4:1.0.0'
@@ -78,14 +73,29 @@ dependencies {
   }
   androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
 }
-jacoco {
-  toolVersion = "0.8.3"
+
+junitJacoco {
+  jacocoVersion = "$versions.jacoco"
+  //ignoreProjects = [] // type String array
+  // exclusion lists taken from https://github.com/arturdm/jacoco-android-gradle-plugin
+  excludes = [
+      // Android excludes
+      '**/R.class',
+      '**/R$*.class',
+      '**/BuildConfig.*',
+      '**/Manifest*.*',
+      // Data bindging
+      'android/databinding/**/*.class',
+      '**/android/databinding/*Binding.class',
+      '**/BR.*',
+      // Dagger 2
+      '**/*_MembersInjector.class',
+      '**/Dagger*Component.class',
+      '**/Dagger*Component$Builder.class',
+      '**/*Module_*Factory.class',
+      '**/AutoValue_*.*', '**/*JavascriptBridge.class', 'jdk.internal.*', '*$Impl_*']
+  includeNoLocationClasses = true
+  includeInstrumentationCoverageInMergedReport = false
 }
-jacocoAndroidUnitTestReport {
-  csv.enabled false
-  html.enabled true
-  xml.enabled true
-  excludes += ['**/AutoValue_*.*',
-      '**/*JavascriptBridge.class', 'jdk.internal.*', '*$Impl_*']
-}
+
 apply plugin: 'com.google.gms.google-services'

--- a/weather-app/build.gradle
+++ b/weather-app/build.gradle
@@ -4,15 +4,15 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: "com.vanniktech.android.junit.jacoco"
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion "28.0.3"
+  compileSdkVersion 29
+  buildToolsVersion "29.0.3"
 
   defaultConfig {
     applicationId "rcgonzalezf.org.weather"
     minSdkVersion 14
-    targetSdkVersion 28
-    versionCode 5
-    versionName "0.2.1"
+    targetSdkVersion 29
+    versionCode 6
+    versionName "0.2.2"
 
     testApplicationId "org.rcgonzalezf.weather.test"
     testHandleProfiling true

--- a/weather-app/src/androidTest/java/org/rcgonzalezf/weather/espresso/navigation/WeatherListUi.kt
+++ b/weather-app/src/androidTest/java/org/rcgonzalezf/weather/espresso/navigation/WeatherListUi.kt
@@ -33,8 +33,7 @@ class WeatherListUi {
 
     class Verifications {
         internal fun checkWeatherResultCity(expectedCity: String) {
-            onIdle()
-            // TODO what next onView is doing?
+            Thread.sleep(1000)
             onView(withId(R.id.main_recycler_view))
             onView(RecyclerViewMatcher(R.id.main_recycler_view).atPosition(1))
                     .check(matches(hasDescendant(withText(expectedCity))))

--- a/weather-library/build.gradle
+++ b/weather-library/build.gradle
@@ -4,14 +4,14 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: "com.vanniktech.android.junit.jacoco"
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion "28.0.3"
+  compileSdkVersion 29
+  buildToolsVersion "29.0.3"
 
   defaultConfig {
     minSdkVersion 14
-    targetSdkVersion 28
-    versionCode 5
-    versionName "0.2.1"
+    targetSdkVersion 29
+    versionCode 6
+    versionName "0.2.2"
   }
   buildTypes {
     release {
@@ -52,7 +52,7 @@ dependencies {
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:1.10.19'
-  testImplementation 'org.robolectric:robolectric:4.3'
+  testImplementation 'org.robolectric:robolectric:4.3.1'
   testImplementation 'nl.jqno.equalsverifier:equalsverifier:2.1.5'
   testImplementation 'org.meanbean:meanbean:2.0.3'
 }

--- a/weather-library/build.gradle
+++ b/weather-library/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'jacoco-android'
+apply plugin: "com.vanniktech.android.junit.jacoco"
 
 android {
   compileSdkVersion 28
@@ -29,11 +29,6 @@ android {
     unitTests {
       includeAndroidResources = true
     }
-    unitTests.all {
-      jacoco {
-        includeNoLocationClasses = true
-      }
-    }
   }
 
   lintOptions {
@@ -45,7 +40,7 @@ android {
 
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
 
   implementation 'androidx.appcompat:appcompat:1.0.0'
   implementation 'com.squareup.retrofit2:retrofit:2.1.0'
@@ -62,19 +57,27 @@ dependencies {
   testImplementation 'org.meanbean:meanbean:2.0.3'
 }
 
+junitJacoco {
+  jacocoVersion = "$versions.jacoco"
+  //ignoreProjects = [] // type String array
 
-jacoco {
-  toolVersion = "0.8.4"
-}
-
-tasks.withType(Test) {
-  jacoco.includeNoLocationClasses = true
-}
-
-jacocoAndroidUnitTestReport {
-  csv.enabled false
-  html.enabled true
-  xml.enabled true
-  excludes += ['**/AutoValue_*.*',
-      '**/*JavascriptBridge.class', 'jdk.internal.*', '*$Impl_*']
+  // exclusion lists taken from https://github.com/arturdm/jacoco-android-gradle-plugin
+  excludes = [
+      // Android excludes
+      '**/R.class',
+      '**/R$*.class',
+      '**/BuildConfig.*',
+      '**/Manifest*.*',
+      // Data bindging
+      'android/databinding/**/*.class',
+      '**/android/databinding/*Binding.class',
+      '**/BR.*',
+      // Dagger 2
+      '**/*_MembersInjector.class',
+      '**/Dagger*Component.class',
+      '**/Dagger*Component$Builder.class',
+      '**/*Module_*Factory.class',
+      '**/AutoValue_*.*', '**/*JavascriptBridge.class', 'jdk.internal.*', '*$Impl_*']
+  includeNoLocationClasses = true
+  includeInstrumentationCoverageInMergedReport = false
 }

--- a/weather-library/src/test/java/org/rcgonzalezf/weather/openweather/network/OpenWeatherExecutorTest.java
+++ b/weather-library/src/test/java/org/rcgonzalezf/weather/openweather/network/OpenWeatherExecutorTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(application = WeatherTestLibApp.class)
+@Config(application = WeatherTestLibApp.class, sdk = 28)
 public class OpenWeatherExecutorTest {
 
   private OpenWeatherExecutor uut;


### PR DESCRIPTION
Updating the Gradle version.

- This PR required other updates. 
- The jacoco plug in used before wasn't compatible with the latest gradle versions.
- The new jacoco plug in runs espresso tests, so I had to update Travis.yml to support UI tests and spin up an emulator.
- Fixed the flaky test, by adding a `Thread.sleep`, it will need to be checked later.